### PR TITLE
Found a typo in the templating docs

### DIFF
--- a/doc/reference/guide/src/main/asciidoc/templating.asciidoc
+++ b/doc/reference/guide/src/main/asciidoc/templating.asciidoc
@@ -29,7 +29,7 @@ can be used for outputting markup:
 
 ----
 <ul>
-<% ["red","green","blue"].each({ color -> out.print("<li>The sky is ${blue}</li>") }) %>
+<% ["red","green","blue"].each { color -> out.print("<li>The sky is ${color}</li>") } %>
 </ul>
 ----
 


### PR DESCRIPTION
Looking through the docs for a [Stackoverflow question](http://stackoverflow.com/questions/19809662/why-we-use-gtmpl-file-in-juzu-framework-development), I spotted a typo
