### PR TITLE
JacksonUnmarshaller is ignored

### DIFF
--- a/core/src/main/java/juzu/impl/common/Tools.java
+++ b/core/src/main/java/juzu/impl/common/Tools.java
@@ -170,53 +170,7 @@ public class Tools {
   }
 
   public static <T> Iterable<T> loadService(Class<T> service, ClassLoader loader) {
-    final Iterable<T> i = ServiceLoader.load(service, loader);
-    return new Iterable<T>() {
-      @Override
-      public Iterator<T> iterator() {
-        return new Iterator<T>() {
-
-          Iterator<T> a = i.iterator();
-          T next;
-
-          @Override
-          public boolean hasNext() {
-            while (a != null && a.hasNext()) {
-              try {
-                next = a.next();
-                if(next != null) {
-                  return true;
-                }
-              }
-              catch (Exception e) {
-                // Ignore
-              }
-            }
-            return next != null;
-          }
-
-          @Override
-          public T next() {
-            if(next != null) {
-              T tmp = next;
-              next = null;
-              return tmp;
-            } else if (!hasNext()) {
-              throw new NoSuchElementException();
-            } else {
-              T tmp = next;
-              next = null;
-              return tmp;
-            }
-          }
-
-          @Override
-          public void remove() {
-            throw new UnsupportedOperationException();
-          }
-        };
-      }
-    };
+    return ServiceLoader.load(service, loader);
   }
 
   public static Class<?> getPackageClass(ClassLoader loader, String pkgName) {

--- a/core/src/main/java/juzu/impl/common/Tools.java
+++ b/core/src/main/java/juzu/impl/common/Tools.java
@@ -184,9 +184,9 @@ public class Tools {
             while (a != null && a.hasNext()) {
               try {
                 next = a.next();
-				if(next != null) {
-					return true;
-				}
+                if(next != null) {
+                  return true;
+                }
               }
               catch (Exception e) {
                 // Ignore

--- a/core/src/main/java/juzu/impl/common/Tools.java
+++ b/core/src/main/java/juzu/impl/common/Tools.java
@@ -184,6 +184,9 @@ public class Tools {
             while (a != null && a.hasNext()) {
               try {
                 next = a.next();
+				if(next != null) {
+					return true;
+				}
               }
               catch (Exception e) {
                 // Ignore

--- a/core/src/main/java/juzu/impl/common/Tools.java
+++ b/core/src/main/java/juzu/impl/common/Tools.java
@@ -197,7 +197,11 @@ public class Tools {
 
           @Override
           public T next() {
-            if (!hasNext()) {
+            if(next != null) {
+              T tmp = next;
+              next = null;
+              return tmp;
+            } else if (!hasNext()) {
               throw new NoSuchElementException();
             } else {
               T tmp = next;

--- a/core/src/test/java/juzu/impl/common/ServiceA.java
+++ b/core/src/test/java/juzu/impl/common/ServiceA.java
@@ -1,0 +1,5 @@
+package juzu.impl.common;
+
+public abstract class ServiceA {
+  
+}

--- a/core/src/test/java/juzu/impl/common/ServiceAImpl.java
+++ b/core/src/test/java/juzu/impl/common/ServiceAImpl.java
@@ -1,0 +1,5 @@
+package juzu.impl.common;
+
+public class ServiceAImpl {
+  
+}

--- a/core/src/test/java/juzu/impl/common/ServiceB.java
+++ b/core/src/test/java/juzu/impl/common/ServiceB.java
@@ -1,0 +1,5 @@
+package juzu.impl.common;
+
+public abstract class ServiceB {
+  
+}

--- a/core/src/test/java/juzu/impl/common/ServiceBImpl1.java
+++ b/core/src/test/java/juzu/impl/common/ServiceBImpl1.java
@@ -1,0 +1,5 @@
+package juzu.impl.common;
+
+public class ServiceBImpl1 extends ServiceB {
+  
+}

--- a/core/src/test/java/juzu/impl/common/ServiceBImpl2.java
+++ b/core/src/test/java/juzu/impl/common/ServiceBImpl2.java
@@ -1,0 +1,5 @@
+package juzu.impl.common;
+
+public class ServiceBImpl2 extends ServiceB {
+  
+}

--- a/core/src/test/java/juzu/impl/common/ServiceBImpl3.java
+++ b/core/src/test/java/juzu/impl/common/ServiceBImpl3.java
@@ -1,0 +1,5 @@
+package juzu.impl.common;
+
+public class ServiceBImpl3 extends ServiceB {
+  
+}

--- a/core/src/test/java/juzu/impl/common/ToolsTestCase.java
+++ b/core/src/test/java/juzu/impl/common/ToolsTestCase.java
@@ -16,20 +16,25 @@
 
 package juzu.impl.common;
 
-import juzu.test.AbstractTestCase;
-import org.junit.Test;
-import org.w3c.dom.Element;
-import org.xml.sax.InputSource;
-
-import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import juzu.impl.request.EntityUnmarshaller;
+import juzu.test.AbstractTestCase;
+
+import org.junit.Test;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
 
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ToolsTestCase extends AbstractTestCase {
@@ -254,4 +259,26 @@ public class ToolsTestCase extends AbstractTestCase {
     assertEquals("", Tools.interpolate("${bar}", context));
     assertEquals("juu", Tools.interpolate("${bar:juu}", context));
   }
+
+  @Test
+  public void testLoadService() {
+    Iterable<ServiceA> iterableServiceA = Tools.loadService(ServiceA.class, getClass().getClassLoader());
+    assertFalse("ServiceA shouldn't have a known service impl", iterableServiceA.iterator().hasNext());
+
+    List<Class<? extends ServiceB>> serviceBImpls = new ArrayList<Class<? extends ServiceB>>();
+    serviceBImpls.add(ServiceBImpl1.class);
+    serviceBImpls.add(ServiceBImpl2.class);
+    serviceBImpls.add(ServiceBImpl3.class);
+
+    Iterable<ServiceB> iterableServiceB = Tools.loadService(ServiceB.class, getClass().getClassLoader());
+    int count = 0;
+    for (ServiceB serviceB : iterableServiceB) {
+      assertNotNull("Returned Service is null", serviceB);
+      serviceBImpls.remove(serviceB.getClass());
+      count++;
+    }
+    assertEquals("Returned services missed service of type: " + serviceBImpls, 0, serviceBImpls.size());
+    assertEquals("Services count is different than expected", 3, count);
+  }
+
 }

--- a/core/src/test/resources/META-INF/services/juzu.impl.common.ServiceB
+++ b/core/src/test/resources/META-INF/services/juzu.impl.common.ServiceB
@@ -1,0 +1,3 @@
+juzu.impl.common.ServiceBImpl1
+juzu.impl.common.ServiceBImpl2
+juzu.impl.common.ServiceBImpl3


### PR DESCRIPTION
When @Jackdon annotation is used in a parameter of a method method, the JacksonUnmarshaller is always ignored and only FileUploadUnmarshaller is used instead.
Cause: Tools.loadService returns only the last element in the Iterable.