### PR TITLE
HTTP status code should be 500 on error

### DIFF
--- a/core/src/main/java/juzu/impl/bridge/spi/portlet/PortletMimeBridge.java
+++ b/core/src/main/java/juzu/impl/bridge/spi/portlet/PortletMimeBridge.java
@@ -182,6 +182,7 @@ public abstract class PortletMimeBridge<Rq extends PortletRequest, Rs extends Mi
         }
         writer.append("</div>");
         writer.close();
+        resp.addProperty(ResourceResponse.HTTP_STATUS_CODE, "500");
       } else {
         throw new PortletException(error.getCause());
       }


### PR DESCRIPTION
JUZU Ajax request returns HTTP 200 OK when an error occurs.