### PR TITLE
Use UTF-8 charset for response as default charset

### DIFF
--- a/core/src/main/java/juzu/impl/bridge/spi/portlet/PortletMimeBridge.java
+++ b/core/src/main/java/juzu/impl/bridge/spi/portlet/PortletMimeBridge.java
@@ -73,7 +73,7 @@ public abstract class PortletMimeBridge<Rq extends PortletRequest, Rs extends Mi
       Stream stream = new Stream() {
 
         /** . */
-        private Charset charset = Tools.ISO_8859_1;
+        private Charset charset = Tools.UTF_8;
 
         /** . */
         private String mimeType = null;


### PR DESCRIPTION
Using latin1 charset, the default behavior will cause a bad display for accented characters.
So the default should be at least UTF-8. Or better, use the HTTP Request charset.