### PR TITLE
Remove unnecessary bottleneck when retrieving Requests

### DIFF
--- a/core/src/main/java/juzu/impl/plugin/controller/ControllerService.java
+++ b/core/src/main/java/juzu/impl/plugin/controller/ControllerService.java
@@ -24,6 +24,7 @@ import juzu.impl.plugin.application.Application;
 import juzu.impl.request.ContextualParameter;
 import juzu.impl.request.ControlParameter;
 import juzu.impl.request.ControllerHandler;
+import juzu.impl.request.RequestFilter;
 import juzu.impl.value.ValueType;
 import juzu.request.Phase;
 import juzu.io.UndeclaredIOException;
@@ -36,11 +37,13 @@ import juzu.impl.request.Request;
 import juzu.request.RequestParameter;
 
 import javax.inject.Inject;
+
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ControllerService extends ApplicationService {
@@ -50,6 +53,9 @@ public class ControllerService extends ApplicationService {
 
   /** . */
   final ArrayList<ValueType<?>> valueTypes = new ArrayList<ValueType<?>>();
+
+  /** . */
+  final List<RequestFilter<?>>                             filters = new ArrayList<RequestFilter<?>>();
 
   /** . */
   @Inject
@@ -82,6 +88,20 @@ public class ControllerService extends ApplicationService {
 
   public InjectionContext<?, ?> getInjectionContext() {
     return application.getInjectionContext();
+  }
+  
+  public List<RequestFilter<?>> getFilters() {
+    if (filters.isEmpty()) {
+      synchronized (filters) {
+        if (filters.isEmpty()) {
+          // Build the filter list
+          for (RequestFilter<?> filter : getInjectionContext().resolveInstances(RequestFilter.class)) {
+            filters.add(filter);
+          }
+        }
+      }
+    }
+    return filters;
   }
 
   public <T> ValueType<T> resolveValueType(Class<T> type) {

--- a/core/src/main/java/juzu/impl/request/Stage.java
+++ b/core/src/main/java/juzu/impl/request/Stage.java
@@ -48,13 +48,13 @@ import java.util.Map;
 public abstract class Stage {
 
   /** . */
-  private int index = 0;
+  private int                                              index   = 0;
 
   /** . */
-  final Request request;
+  final Request                                            request;
 
   /** . */
-  final List<RequestFilter<?>> filters;
+  final List<RequestFilter<?>>                             filters;
 
   public Request getRequest() {
     return request;
@@ -64,7 +64,7 @@ public abstract class Stage {
 
     // Build the filter list
     List<RequestFilter<?>> filters = new ArrayList<RequestFilter<?>>();
-    for (RequestFilter<?> filter : request.controllerPlugin.getInjectionContext().resolveInstances(RequestFilter.class)) {
+    for (RequestFilter<?> filter : request.controllerPlugin.getFilters()) {
       if (getClass().isAssignableFrom(filter.getStageType())) {
         filters.add(filter);
       }
@@ -80,7 +80,7 @@ public abstract class Stage {
       RequestFilter plugin = filters.get(index);
       try {
         index++;
-        return (Response)plugin.handle(this);
+        return (Response) plugin.handle(this);
       }
       finally {
         index--;
@@ -113,10 +113,10 @@ public abstract class Stage {
       parameterArguments.putAll(request.bridge.getRequestArguments());
 
       //
-      Map<ContextualParameter,Object> contextualArguments = request.getContextualArguments();
+      Map<ContextualParameter, Object> contextualArguments = request.getContextualArguments();
       for (ControlParameter controlParameter : request.handler.getParameters()) {
         if (controlParameter instanceof ContextualParameter) {
-          ContextualParameter contextualParameter = (ContextualParameter)controlParameter;
+          ContextualParameter contextualParameter = (ContextualParameter) controlParameter;
           if (!contextualArguments.containsKey(contextualParameter)) {
             contextualArguments.put(contextualParameter, null);
           }
@@ -183,11 +183,11 @@ public abstract class Stage {
 
         // Build arguments
         Object[] args = new Object[handler.getParameters().size()];
-        for (int i = 0;i < args.length;i++) {
+        for (int i = 0; i < args.length; i++) {
           ControlParameter parameter = handler.getParameters().get(i);
           Object value;
           if (parameter instanceof PhaseParameter) {
-            PhaseParameter phaseParam = (PhaseParameter)parameter;
+            PhaseParameter phaseParam = (PhaseParameter) parameter;
             RequestParameter requestParam = request.getParameterArguments().get(phaseParam.getMappedName());
             if (requestParam != null) {
               ValueType<?> valueType = request.controllerPlugin.resolveValueType(phaseParam.getValueType());
@@ -217,9 +217,9 @@ public abstract class Stage {
               } else if (type == long.class) {
                 value = 0L;
               } else if (type == byte.class) {
-                value = (byte)0;
+                value = (byte) 0;
               } else if (type == short.class) {
-                value = (short)0;
+                value = (short) 0;
               } else if (type == boolean.class) {
                 value = false;
               } else if (type == float.class) {
@@ -231,7 +231,7 @@ public abstract class Stage {
               }
             }
           } else if (parameter instanceof BeanParameter) {
-            BeanParameter beanParam = (BeanParameter)parameter;
+            BeanParameter beanParam = (BeanParameter) parameter;
             Class<?> type = beanParam.getType();
             try {
               value = beanParam.createMappedBean(request.controllerPlugin, handler.requiresPrefix, type, beanParam.getName(), request.getParameterArguments());
@@ -240,7 +240,7 @@ public abstract class Stage {
               value = null;
             }
           } else {
-            ContextualParameter contextualParameter = (ContextualParameter)parameter;
+            ContextualParameter contextualParameter = (ContextualParameter) parameter;
             value = request.getContextualArguments().get(contextualParameter);
             if (value == null) {
               Class<?> contextualType = contextualParameter.getType();
@@ -293,10 +293,10 @@ public abstract class Stage {
     private final RequestContext context;
 
     /** . */
-    private final Object controller;
+    private final Object         controller;
 
     /** . */
-    private final Object[] args;
+    private final Object[]       args;
 
     public LifeCycle(Request request, RequestContext context, Object controller, Object[] args) {
       super(request);
@@ -311,7 +311,7 @@ public abstract class Stage {
       // Begin request callback
       if (controller instanceof juzu.request.RequestLifeCycle) {
         try {
-          ((juzu.request.RequestLifeCycle)controller).beginRequest(context);
+          ((juzu.request.RequestLifeCycle) controller).beginRequest(context);
         }
         catch (Exception e) {
           return new Response.Error(e);
@@ -328,7 +328,7 @@ public abstract class Stage {
         // End request callback
         if (controller instanceof juzu.request.RequestLifeCycle) {
           try {
-            ((juzu.request.RequestLifeCycle)controller).endRequest(context);
+            ((juzu.request.RequestLifeCycle) controller).endRequest(context);
           }
           catch (Exception e) {
             context.setResponse(Response.error(e));
@@ -353,10 +353,10 @@ public abstract class Stage {
     private final RequestContext context;
 
     /** . */
-    private final Object controller;
+    private final Object         controller;
 
     /** . */
-    private final Object[] args;
+    private final Object[]       args;
 
     public Invoke(Request request, RequestContext context, Object controller, Object[] args) {
       super(request);
@@ -388,7 +388,7 @@ public abstract class Stage {
         MimeType mimeType = null;
         for (Annotation annotation : context.getHandler().getMethod().getDeclaredAnnotations()) {
           if (annotation instanceof MimeType) {
-            mimeType = (MimeType)annotation;
+            mimeType = (MimeType) annotation;
           } else {
             mimeType = annotation.annotationType().getAnnotation(MimeType.class);
           }
@@ -406,7 +406,7 @@ public abstract class Stage {
           // @Action -> Response.Action
           // @View -> Response.Mime
           // as we can do it
-          Response resp = (Response)ret;
+          Response resp = (Response) ret;
           if (mimeType != null) {
             resp = resp.with(PropertyType.MIME_TYPE, mimeType.value()[0]);
           }

--- a/core/src/main/java/juzu/impl/request/Stage.java
+++ b/core/src/main/java/juzu/impl/request/Stage.java
@@ -48,13 +48,13 @@ import java.util.Map;
 public abstract class Stage {
 
   /** . */
-  private int                                              index   = 0;
+  private int index = 0;
 
   /** . */
-  final Request                                            request;
+  final Request request;
 
   /** . */
-  final List<RequestFilter<?>>                             filters;
+  final List<RequestFilter<?>> filters;
 
   public Request getRequest() {
     return request;
@@ -80,7 +80,7 @@ public abstract class Stage {
       RequestFilter plugin = filters.get(index);
       try {
         index++;
-        return (Response) plugin.handle(this);
+        return (Response)plugin.handle(this);
       }
       finally {
         index--;
@@ -113,10 +113,10 @@ public abstract class Stage {
       parameterArguments.putAll(request.bridge.getRequestArguments());
 
       //
-      Map<ContextualParameter, Object> contextualArguments = request.getContextualArguments();
+      Map<ContextualParameter,Object> contextualArguments = request.getContextualArguments();
       for (ControlParameter controlParameter : request.handler.getParameters()) {
         if (controlParameter instanceof ContextualParameter) {
-          ContextualParameter contextualParameter = (ContextualParameter) controlParameter;
+          ContextualParameter contextualParameter = (ContextualParameter)controlParameter;
           if (!contextualArguments.containsKey(contextualParameter)) {
             contextualArguments.put(contextualParameter, null);
           }
@@ -183,11 +183,11 @@ public abstract class Stage {
 
         // Build arguments
         Object[] args = new Object[handler.getParameters().size()];
-        for (int i = 0; i < args.length; i++) {
+        for (int i = 0;i < args.length;i++) {
           ControlParameter parameter = handler.getParameters().get(i);
           Object value;
           if (parameter instanceof PhaseParameter) {
-            PhaseParameter phaseParam = (PhaseParameter) parameter;
+            PhaseParameter phaseParam = (PhaseParameter)parameter;
             RequestParameter requestParam = request.getParameterArguments().get(phaseParam.getMappedName());
             if (requestParam != null) {
               ValueType<?> valueType = request.controllerPlugin.resolveValueType(phaseParam.getValueType());
@@ -217,9 +217,9 @@ public abstract class Stage {
               } else if (type == long.class) {
                 value = 0L;
               } else if (type == byte.class) {
-                value = (byte) 0;
+                value = (byte)0;
               } else if (type == short.class) {
-                value = (short) 0;
+                value = (short)0;
               } else if (type == boolean.class) {
                 value = false;
               } else if (type == float.class) {
@@ -231,7 +231,7 @@ public abstract class Stage {
               }
             }
           } else if (parameter instanceof BeanParameter) {
-            BeanParameter beanParam = (BeanParameter) parameter;
+            BeanParameter beanParam = (BeanParameter)parameter;
             Class<?> type = beanParam.getType();
             try {
               value = beanParam.createMappedBean(request.controllerPlugin, handler.requiresPrefix, type, beanParam.getName(), request.getParameterArguments());
@@ -240,7 +240,7 @@ public abstract class Stage {
               value = null;
             }
           } else {
-            ContextualParameter contextualParameter = (ContextualParameter) parameter;
+            ContextualParameter contextualParameter = (ContextualParameter)parameter;
             value = request.getContextualArguments().get(contextualParameter);
             if (value == null) {
               Class<?> contextualType = contextualParameter.getType();
@@ -293,10 +293,10 @@ public abstract class Stage {
     private final RequestContext context;
 
     /** . */
-    private final Object         controller;
+    private final Object controller;
 
     /** . */
-    private final Object[]       args;
+    private final Object[] args;
 
     public LifeCycle(Request request, RequestContext context, Object controller, Object[] args) {
       super(request);
@@ -311,7 +311,7 @@ public abstract class Stage {
       // Begin request callback
       if (controller instanceof juzu.request.RequestLifeCycle) {
         try {
-          ((juzu.request.RequestLifeCycle) controller).beginRequest(context);
+          ((juzu.request.RequestLifeCycle)controller).beginRequest(context);
         }
         catch (Exception e) {
           return new Response.Error(e);
@@ -328,7 +328,7 @@ public abstract class Stage {
         // End request callback
         if (controller instanceof juzu.request.RequestLifeCycle) {
           try {
-            ((juzu.request.RequestLifeCycle) controller).endRequest(context);
+            ((juzu.request.RequestLifeCycle)controller).endRequest(context);
           }
           catch (Exception e) {
             context.setResponse(Response.error(e));
@@ -353,10 +353,10 @@ public abstract class Stage {
     private final RequestContext context;
 
     /** . */
-    private final Object         controller;
+    private final Object controller;
 
     /** . */
-    private final Object[]       args;
+    private final Object[] args;
 
     public Invoke(Request request, RequestContext context, Object controller, Object[] args) {
       super(request);
@@ -388,7 +388,7 @@ public abstract class Stage {
         MimeType mimeType = null;
         for (Annotation annotation : context.getHandler().getMethod().getDeclaredAnnotations()) {
           if (annotation instanceof MimeType) {
-            mimeType = (MimeType) annotation;
+            mimeType = (MimeType)annotation;
           } else {
             mimeType = annotation.annotationType().getAnnotation(MimeType.class);
           }
@@ -406,7 +406,7 @@ public abstract class Stage {
           // @Action -> Response.Action
           // @View -> Response.Mime
           // as we can do it
-          Response resp = (Response) ret;
+          Response resp = (Response)ret;
           if (mimeType != null) {
             resp = resp.with(PropertyType.MIME_TYPE, mimeType.value()[0]);
           }


### PR DESCRIPTION
Actually, there a big bottleneck JUZU applications 
Each time a JUZU application is displayed in a page, all other HTTP requests that wants to display any other page that uses JUZU will be blocked because of one operation in JUZU application lifecycle.
In fact, inside the "retrieve the response" phase, the operation "get the *filters* beans associated to the Stage type(Unmarshaling, Handler, Lifecycle, Invoke)" is synchronized (blocker, one operation at a time).
The *filters* are SINGLETON beans, so we should put those beans in the JUZU controller context once for all.