### PR TITLE
Avoid displaying NPE when getting not found resource

### DIFF
--- a/core/src/main/java/juzu/impl/asset/AssetServer.java
+++ b/core/src/main/java/juzu/impl/asset/AssetServer.java
@@ -68,7 +68,7 @@ public class AssetServer {
               content = new AssetResource(resource, null);
             }
           }
-          if (content != null) {
+          if (content != null && content.url != null) {
             InputStream in;
             long lastModified;
             URLConnection conn = content.url.openConnection();

--- a/plugins/less4j/src/main/java/juzu/plugin/less4j/impl/LessAsset.java
+++ b/plugins/less4j/src/main/java/juzu/plugin/less4j/impl/LessAsset.java
@@ -17,6 +17,7 @@ package juzu.plugin.less4j.impl;
 
 import com.github.sommeri.less4j.Less4jException;
 import com.github.sommeri.less4j.LessCompiler;
+import com.github.sommeri.less4j.LessCompiler.Configuration;
 import com.github.sommeri.less4j.LessSource;
 import com.github.sommeri.less4j.core.ThreadUnsafeLessCompiler;
 import juzu.asset.AssetLocation;
@@ -68,7 +69,9 @@ public class LessAsset extends Asset {
   public InputStream open(String s, URLConnection resource) throws IOException {
     LessCompiler compiler = new ThreadUnsafeLessCompiler();
     try {
-      LessCompiler.CompilationResult result = compiler.compile(resource.getURL());
+      Configuration configuration = new Configuration();
+      configuration.setLinkSourceMap(false);
+      LessCompiler.CompilationResult result = compiler.compile(resource.getURL(), configuration);
       return new ByteArrayInputStream(result.getCss().getBytes());
     }
     catch (Less4jException e) {


### PR DESCRIPTION
The CSS source map is referenced in generated CSS using "juzu-plugins-less4j".
This PR will avoid generating this reference and will avoid useless NPE display in server log.